### PR TITLE
Create an error re-insertion example (vibe-kanban)

### DIFF
--- a/error_reinsertion/hello.py
+++ b/error_reinsertion/hello.py
@@ -1,0 +1,6 @@
+def main():
+    print("Hello from error-reinsertion!")
+
+
+if __name__ == "__main__":
+    main()

--- a/error_reinsertion/main.py
+++ b/error_reinsertion/main.py
@@ -1,0 +1,38 @@
+"""
+Error Reinsertion Example
+
+This example demonstrates a common issue where an LLM provides overly formal 
+or academic responses when users want casual, friendly explanations.
+"""
+
+import os
+from mirascope.core import openai
+
+
+@openai.call("gpt-4o-mini")
+def explain_concept(topic: str) -> str:
+    """Explain a programming concept in simple terms."""
+    return f"Explain what {topic} is in programming. Keep it simple and easy to understand."
+
+
+def main():
+    # Set up OpenAI API key (user should set this)
+    if not os.getenv("OPENAI_API_KEY"):
+        print("Please set your OPENAI_API_KEY environment variable")
+        return
+    
+    # Example query that often gets overly formal responses
+    topic = "recursion"
+    
+    print(f"Asking for explanation of: {topic}")
+    print("-" * 50)
+    
+    try:
+        response = explain_concept(topic)
+        print(response)
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/error_reinsertion/pyproject.toml
+++ b/error_reinsertion/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "error-reinsertion"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "mirascope[openai]>=1.25.2",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,4 @@ dev = [
 ]
 
 [tool.uv.workspace]
-members = ["durable-streaming"]
+members = ["durable-streaming", "error_reinsertion"]

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ resolution-markers = [
 members = [
     "ai-livestreams",
     "durable-streaming",
+    "error-reinsertion",
 ]
 
 [[package]]
@@ -238,6 +239,17 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "ipdb", specifier = ">=0.13.13" }]
+
+[[package]]
+name = "error-reinsertion"
+version = "0.1.0"
+source = { virtual = "error_reinsertion" }
+dependencies = [
+    { name = "mirascope", extra = ["openai"] },
+]
+
+[package.metadata]
+requires-dist = [{ name = "mirascope", extras = ["openai"], specifier = ">=1.25.2" }]
 
 [[package]]
 name = "et-xmlfile"


### PR DESCRIPTION
I want to live code an error reinsertion implementation, but I want to set myself up with a good example. Error reinsertion is effectively feeding errors back to the LLM so that it can self-correct.

The live coding will start with a simple example containing one LLM call that has some issue in its responses (for you to come up with! maybe it's the tone? maybe it's using em-dashes? Something else?). We want the problem with responses to be plausible and something many people likely face.

This should be done in a *new* directory called "error_reinsertion".

All work should be performed in that subdirectory.

1. Initialize a uv environment
2. uv add 'mirascope[openai]'
3. Create an example program that has a simple mirascope function (no response_model) with a hardcoded query that is informational.
4. main function to run this

This should be a runnable script. I will pick it up from there!